### PR TITLE
Show information about papirinnsending in søknad PDF

### DIFF
--- a/data/supdfgen/soknad.json
+++ b/data/supdfgen/soknad.json
@@ -115,9 +115,15 @@
       "skylderNoenMegPengerBeløp": 30,
       "kontanterBeløp": 40
     },
-    "forNav": {
+    "forNav2": {
       "harFullmektigEllerVerge": "verge",
       "type": "DigitalSøknad"
+    },
+    "forNav": {
+      "mottaksdatoForSøknad": "13.12.2020",
+      "grunnForPapirinnsending": "VergeHarSøktPåVegneAvBruker",
+      "annenGrunn": "",
+      "type": "Papirsøknad"
     },
     "ektefelle": {
       "formue": {

--- a/templates/supdfgen/soknad.hbs
+++ b/templates/supdfgen/soknad.hbs
@@ -66,17 +66,49 @@
                 <td>Søknadsdato:</td>
                 <td>{{søknadOpprettet}}</td>
             </tr>
-            <tr>
-                <td>Har søker møtt personlig:</td>
-                <td>{{#if harFullmektigEllerVerge}} Nei {{else}} Ja {{/if}}</td>
-            </tr>
-
-            {{#if harFullmektigEllerVerge}}
+            {{#eq type "DigitalSøknad"}}
                 <tr>
-                    <td>Har søker fullmektig eller verge?</td>
-                    <td>{{harFullmektigEllerVerge}}</td>
+                    <td>Har søker møtt personlig:</td>
+                    <td>{{#if harFullmektigEllerVerge}} Nei {{else}} Ja {{/if}}</td>
                 </tr>
-            {{/if}}
+
+                {{#if harFullmektigEllerVerge}}
+                    <tr>
+                        <td>Har søker fullmektig eller verge?</td>
+                        <td>{{harFullmektigEllerVerge}}</td>
+                    </tr>
+                {{/if}}
+            {{/eq}}
+            {{#eq type "Papirsøknad"}}
+                <tr>
+                    <td>Søknad innsendt på papir:</td>
+                    <td>Ja</td>
+                </tr>
+                <tr>
+                    <td>Mottatt dato:</td>
+                    <td>{{mottaksdatoForSøknad}}</td>
+                </tr>
+                <tr>
+                    <td>Grunn for papirinnsending:</td>
+                    <td>
+                        {{#eq grunnForPapirinnsending "VergeHarSøktPåVegneAvBruker"}}
+                            Verge har søkt på vegne av bruker
+                        {{/eq}}
+                        {{#eq grunnForPapirinnsending "MidlertidigUnntakFraOppmøteplikt"}}
+                            Midlertidig unntak fra oppmøteplikt
+                        {{/eq}}
+                        {{#eq grunnForPapirinnsending "Annet"}}
+                            Annet
+                        {{/eq}}
+                    </td>
+                </tr>
+                {{#eq grunnForPapirinnsending "Annet"}}
+                    <tr>
+                        <td></td>
+                        <td>{{annenGrunn}}</td>
+                    </tr>
+                {{/eq}}
+            {{/eq}}
         {{/with}}
         </tbody>
     </table>


### PR DESCRIPTION
Ideelt sett hadde vi kanskje ikke gjort oversettingen av `grunnForPapirinnsending`-enumen her i pdfgen, men jeg så ikke noen enkel måte å gjøre det på i `su-se-bakover` uten å måtte innføre en _haug_ med nye typer (siden det er `SøknadInnhold`-typen som sendes over hit).