### PR TITLE
Ta vare på whitespace i fritekst

### DIFF
--- a/templates/supdfgen/avvistSøknadFritekst.hbs
+++ b/templates/supdfgen/avvistSøknadFritekst.hbs
@@ -1,7 +1,9 @@
 {{#> supdfgen/partials/base}}
     <div class="mainContent">
         <h3>{{tittel}}</h3>
-        <p>{{fritekst}}</p>
+
+        <p class="fritekst">{{fritekst}}</p>
+
         <p>
             Med vennlig hilsen <br/>
             {{#if saksbehandlerNavn}}{{saksbehandlerNavn}} hos {{/if}}NAV Familie- og pensjonsytelser Ålesund<br/>

--- a/templates/supdfgen/avvistSøknadVedtak.hbs
+++ b/templates/supdfgen/avvistSøknadVedtak.hbs
@@ -2,6 +2,6 @@
     <div class="mainContent">
         <h3>Søknaden din om supplerende stønad er avvist</h3>
 
-        <p>{{fritekst}}</p>
+        <p class="fritekst">{{fritekst}}</p>
     </div>
 {{/supdfgen/partials/avslagBase}}

--- a/templates/supdfgen/partials/base.hbs
+++ b/templates/supdfgen/partials/base.hbs
@@ -92,6 +92,10 @@
             border-top: 1px solid black;
             font-weight: bold;
         }
+
+        .fritekst {
+            white-space: pre-wrap;
+        }
     </style>
     <title>Supplerende stønad</title>
 </head>

--- a/templates/supdfgen/revurderingAvInntekt.hbs
+++ b/templates/supdfgen/revurderingAvInntekt.hbs
@@ -3,9 +3,7 @@
         <h2>Vi har vurdert den supplerende stønaden din på nytt</h2>
 
         <div class="info">
-            <p>
-                {{fritekst}}
-            <p>
+            <p class="fritekst">{{fritekst}}<p>
         </div>
 
         {{> supdfgen/partials/beregning beregningsperioder }}


### PR DESCRIPTION
I nåværende versjon blir all whitespace strippet, og ting havner på én linje.