### PR TITLE
Flytt fødselsnummer under overskriften

### DIFF
--- a/templates/supdfgen/avvistSøknadFritekst.hbs
+++ b/templates/supdfgen/avvistSøknadFritekst.hbs
@@ -1,6 +1,7 @@
 {{#> supdfgen/partials/base}}
     <div class="mainContent">
         <h3>{{tittel}}</h3>
+        {{> supdfgen/partials/fnr personalia }}
 
         <p class="fritekst">{{fritekst}}</p>
 

--- a/templates/supdfgen/avvistSøknadVedtak.hbs
+++ b/templates/supdfgen/avvistSøknadVedtak.hbs
@@ -1,6 +1,7 @@
 {{#> supdfgen/partials/avslagBase}}
     <div class="mainContent">
         <h3>Søknaden din om supplerende stønad er avvist</h3>
+        {{> supdfgen/partials/fnr personalia }}
 
         <p class="fritekst">{{fritekst}}</p>
     </div>

--- a/templates/supdfgen/partials/base.hbs
+++ b/templates/supdfgen/partials/base.hbs
@@ -108,7 +108,6 @@
 
             <div class="personalia">
                 <p>{{fornavn}} {{etternavn}}</p>
-                <p>{{fødselsnummer}}</p>
                 <p>Dato: {{dato}}</p>
             </div>
         </div>

--- a/templates/supdfgen/partials/fnr.hbs
+++ b/templates/supdfgen/partials/fnr.hbs
@@ -1,0 +1,1 @@
+<p>Fødselsnummer {{personalia.fødselsnummer}} (Oppgi fødselsnummer ved henvendelser til oss)</p>

--- a/templates/supdfgen/revurderingAvInntekt.hbs
+++ b/templates/supdfgen/revurderingAvInntekt.hbs
@@ -1,6 +1,7 @@
 {{#> supdfgen/partials/avslagBase}}
     <div class="mainContent">
         <h2>Vi har vurdert den supplerende stønaden din på nytt</h2>
+        {{> supdfgen/partials/fnr personalia }}
 
         <div class="info">
             <p class="fritekst">{{fritekst}}<p>

--- a/templates/supdfgen/søknadTrukket.hbs
+++ b/templates/supdfgen/søknadTrukket.hbs
@@ -1,6 +1,7 @@
 {{#> supdfgen/partials/base}}
     <div class="mainContent">
         <h3>Søknaden din om supplerende stønad er trukket</h3>
+        {{> supdfgen/partials/fnr personalia }}
 
         <p>
             NAV viser til søknaden din om supplerende stønad mottatt {{datoSøknadOpprettet}}.

--- a/templates/supdfgen/vedtakAvslag.hbs
+++ b/templates/supdfgen/vedtakAvslag.hbs
@@ -1,6 +1,7 @@
 {{#> supdfgen/partials/avslagBase}}
     <li class="mainContent">
         <h2>Vi har avslått søknaden din om supplerende stønad</h2>
+        {{> supdfgen/partials/fnr personalia }}
 
         <p>Du har ikke rett til supplerende stønad fordi:</p>
 

--- a/templates/supdfgen/vedtakInnvilgelse.hbs
+++ b/templates/supdfgen/vedtakInnvilgelse.hbs
@@ -1,6 +1,7 @@
 {{#> supdfgen/partials/innvilgelseBase}}
     <div class="mainContent">
         <h2>Du får supplerende stønad</h2>
+        {{> supdfgen/partials/fnr personalia }}
 
         <div class="info">
             <p>


### PR DESCRIPTION
Hovedsaklig for å forsikre oss om at fødselsnummeret ikke vil vises, dersom brevet av en eller annen grunn blir puttet i en vinduskonvolutt