### PR TITLE
Fjern desimaler fra fribeløpsetning når ektefelles inntekt er lavere enn fribeløpet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ PDFene kan testes lokalt på `http://localhost:8081/api/v1/genpdf/<application>/
 http://localhost:8081/api/v1/genpdf/supdfgen/vedtakInnvilgelse
 
 Templatene vil bruke flettedata fra json-fil med samme navn som template i `data/supdfgen`
+
+## Hjelpefunksjoner
+
+https://github.com/navikt/pdfgen/blob/master/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
+
+### Stor forbokstav
+
+Eksempel `{{capitalize sats}}`
+
+### Kronebeløp
+
+Eksempel `{{currency_no satsBeløp true}}`
+
+Boolean-parameteret angir om beløpet skal avrundes til nærmeste hele krone.

--- a/templates/supdfgen/partials/beregning.hbs
+++ b/templates/supdfgen/partials/beregning.hbs
@@ -87,7 +87,7 @@
     </table>
     {{#if fradrag.eps.harFradragMedSumSomErLavereEnnFribeløp}}
         <p>
-            Inntekten til ektefelle/samboer er under fribeløpet på {{currency_no epsFribeløp}} kr per måned og er derfor ikke med i regnestykket for denne perioden.
+            Inntekten til ektefelle/samboer er under fribeløpet på {{currency_no epsFribeløp true}} kr per måned og er derfor ikke med i regnestykket for denne perioden.
         </p>
     {{/if}}
 {{/each}}


### PR DESCRIPTION
Fikset også litt doc på hjelpefunksjonene, slik at det kanskje er litt enklere å skjønne at det siste parameteret i `currency_no`-funksjonen sier om beløpet skal være i hele kroner.