### PR TITLE
Fjern duplikat info fra innvilgelsesbrev

### DIFF
--- a/templates/supdfgen/partials/ekstraInnvilgelsesinformasjon.hbs
+++ b/templates/supdfgen/partials/ekstraInnvilgelsesinformasjon.hbs
@@ -18,13 +18,6 @@
     </div>
 
     <div class="info">
-        <h3>Du må melde fra om utenlandsopphold</h3>
-        <p>Du kan ikke oppholde deg utenfor Norge i mer enn 90 dager sammenhengende, eller til sammen i de 12 månedene
-            du får stønad. Du må melde fra til NAV om dato for når du reiser og dato for når du kommer tilbake. Dette må
-            du fortelle oss før du reiser. Oppholdene må dokumenteres med norsk stempel i pass eller boardingpass.</p>
-    </div>
-
-    <div class="info">
         <h3>Du må også melde fra om endringer som kan ha betydning for stønaden din</h3>
         <p>Dette må melde fra om hvis du:</p>
         <ul>

--- a/templates/supdfgen/partials/innvilgelseBase.hbs
+++ b/templates/supdfgen/partials/innvilgelseBase.hbs
@@ -11,10 +11,6 @@
         <p>
             Bryter du disse reglene kan stønaden din opphøre. Du kan også få krav om å betale tilbake penger.
         </p>
-        <p>
-            Vi kaller deg inn til møte på ditt lokale NAV-kontor to ganger i stønadsperioden.
-            Dersom du ikke møter uten gyldig grunn, stanser vi stønaden din.
-        </p>
     </div>
 
     <div class="info">

--- a/templates/supdfgen/vedtakAvslag.hbs
+++ b/templates/supdfgen/vedtakAvslag.hbs
@@ -98,7 +98,7 @@
         {{/if}}
 
         <span>
-            Vedtaket er gjort etter loven om supplerende stønad for personer med kort botid i Norge §§ {{> supdfgen/partials/commaSeparate avslagsparagrafer}}.
+            Vedtaket er gjort etter lov om supplerende stønad for personer med kort botid i Norge §§ {{> supdfgen/partials/commaSeparate avslagsparagrafer}}.
         </span>
     </div>
 {{/supdfgen/partials/avslagBase}}


### PR DESCRIPTION
Noe info som sto dobbelt opp i info-punktene i brevet og i "vedlegget".