### PR TITLE
Fjern attestant fra hilsen hvis samme som saksbehandler

### DIFF
--- a/templates/supdfgen/partials/hilsen.hbs
+++ b/templates/supdfgen/partials/hilsen.hbs
@@ -1,7 +1,13 @@
 <div class="hilsen">
     <p>
         Med vennlig hilsen <br/>
-        {{#if saksbehandler}}{{saksbehandler}}{{#if attestant}} og {{attestant}}{{/if}} hos {{/if}}NAV Familie- og pensjonsytelser Ålesund<br/>
+        {{#if saksbehandler}}
+            {{saksbehandler}}
+            {{#if attestant}}
+                {{#not_eq saksbehandler attestant}} og {{attestant}}{{/not_eq}}
+            {{/if}} hos
+        {{/if}}
+        NAV Familie- og pensjonsytelser Ålesund <br/>
         <br />
         Postadresse:<br />
         NAV Familie- og pensjonsytelser Ålesund<br />


### PR DESCRIPTION
Dette skjer i utgangspunktet kun i brevet for avslag pga. manglende dokumentasjon. Burde kanskje vært løst ved å type avslaget (eller søknadsbehandlingen den er koblet til), men tar dette som en quickfix uansett.