### PR TITLE
Vis fribeløp for ektefelle kun dersom det er større enn null

### DIFF
--- a/templates/supdfgen/partials/beregning.hbs
+++ b/templates/supdfgen/partials/beregning.hbs
@@ -76,12 +76,12 @@
                     </tr>
                 {{/if}}
             {{/each}}
-        {{#not_eq 0.0 epsFribeløp}}
-            <tr>
-                <td>Fribeløp (Ektefelle/samboer)</td>
-                <td class="beregning__beløp">{{currency_no epsFribeløp}}</td>
-            </tr>
-        {{/not_eq}}
+            {{#gt epsFribeløp 0}}
+                <tr>
+                    <td>Fribeløp (Ektefelle/samboer)</td>
+                    <td class="beregning__beløp">{{currency_no epsFribeløp}}</td>
+                </tr>
+            {{/gt}}
         {{/if}}
         <tr>
             <td><b>Sum per måned</b></td>


### PR DESCRIPTION
Vi hadde en sjekk på dette allerede, men den sjekket om `epsFribeløp: Int` var ulik `0.0`, fribeløp var sannsynligvis en double på et tidspunkt.