### PR TITLE
Legger til forskjellig tekst og avslagsgrunner for alder

### DIFF
--- a/data/supdfgen/vedtakAvslag.json
+++ b/data/supdfgen/vedtakAvslag.json
@@ -21,6 +21,7 @@
     7,
     18
   ],
+  "erAldersbrev": false,
   "harEktefelle": true,
   "halvGrunnbeløp": 10,
   "beregningsperioder": [

--- a/data/supdfgen/vedtakInnvilgelse.json
+++ b/data/supdfgen/vedtakInnvilgelse.json
@@ -10,6 +10,7 @@
     "postnummer": "9807",
     "poststed": "Uranus"
   },
+  "erAldersbrev": false,
   "fradato": "januar 2021",
   "tildato": "desember 2021",
   "harEktefelle": true,

--- a/templates/supdfgen/partials/ekstraInnvilgelsesinformasjon.hbs
+++ b/templates/supdfgen/partials/ekstraInnvilgelsesinformasjon.hbs
@@ -1,6 +1,11 @@
 <div>
     <div class="pagebreak"/>
-    <h2>Viktig informasjon om supplerende stønad til deg som er ufør flyktning</h2>
+    <h2>Viktig informasjon om supplerende stønad til deg som er
+        {{#if erAldersbrev}}
+            over 67 år og har kort botid i Norge
+        {{else}}
+            ufør flyktning
+        {{/if}}</h2>
 
     <div class="info">
         <h3>Du må møte på ditt lokale NAV-kontor</h3>
@@ -83,7 +88,8 @@
 
     <div class="info">
         <h3>Honnørkort</h3>
-        <p>Du har rett til honnørrabatt på offentlig kommunikasjon når du reiser i Norge. Hvis du ikke allerede har honnørkortet, vil du få dette kortet i posten.</p>
+        <p>Du har rett til honnørrabatt på offentlig kommunikasjon når du reiser i Norge. Hvis du ikke allerede har
+            honnørkortet, vil du få dette kortet i posten.</p>
     </div>
 
     <div class="info">

--- a/templates/supdfgen/partials/fellesInfo.hbs
+++ b/templates/supdfgen/partials/fellesInfo.hbs
@@ -15,7 +15,13 @@
 <div class="info">
     <h3>Har du spørsmål?</h3>
     <p>
-        Du finner nyttig informasjon på <a>www.nav.no/supplerendeuf</a>.<br/>
+        Du finner nyttig informasjon på
+        {{#if erAldersbrev}}
+            <a>www.nav.no/supplerende</a>.
+        {{else}}
+            <a>www.nav.no/supplerendeuf</a>.
+        {{/if}}
+        <br/>
         Du kan også kontakte oss på 55 55 33 33.
     </p>
 </div>

--- a/templates/supdfgen/vedtakAvslag.hbs
+++ b/templates/supdfgen/vedtakAvslag.hbs
@@ -19,7 +19,14 @@
                 {{/eq}}
 
                 {{#eq this "OPPHOLDSTILLATELSE" }}
-                    <li>Du har ikke lovlig opphold i Norge.</li>
+                    {{#if erAldersbrev}}
+                        <li>Du har ikke varig lovlig opphold i Norge. Registreringsbevis for EØS-borgere gir ikke
+                            grunnlag for varig oppholdsrett i Norge. Det er et krav at du har varig oppholdsrett for å
+                            kunne få rett til supplerende stønad.
+                        </li>
+                    {{else}}
+                        <li>Du har ikke lovlig opphold i Norge.</li>
+                    {{/if}}
                 {{/eq}}
 
                 {{#eq this "BOR_OG_OPPHOLDER_SEG_I_NORGE" }}
@@ -32,6 +39,33 @@
 
                 {{#eq this "UTENLANDSOPPHOLD_OVER_90_DAGER" }}
                     <li>Du skal oppholde deg utenfor Norge i mer enn 90 dager.</li>
+                {{/eq}}
+
+                {{#eq this "MANGLER_VEDTAK_ALDERSPENSJON_FOLKETRYGDEN"}}
+                    <li>Du har ikke fått vedtak om alderspensjon, som er et krav for å kunne få rett til supplerende
+                        stønad. Dersom du ikke har søkt om alderspensjon, kan du kontakte NAV for å få vurdert om det er
+                        aktuelt.
+                    </li>
+                {{/eq}}
+
+                {{#eq this "MANGLER_VEDTAK_ANDRE_NORSKE_PENSJONSORDNINGER"}}
+                    <li>Du er registrert som medlem i en tjenestepensjonsordning. Vi har ikke mottatt informasjon om at du
+                        har fått vedtak fra denne ordningen. Du må ha utnyttet retten til alle pensjoner i Norge og
+                        utlandet, da det er et krav for å få rett til supplerende stønad.
+                    </li>
+                {{/eq}}
+
+                {{#eq this "MANGLER_VEDTAK_UTENLANDSKE_PENSJONSORDNINGER"}}
+                    <li>Du har ikke fått vedtak om pensjon fra utlandet, som er et krav for å kunne få rett til
+                        supplerende stønad.
+                    </li>
+                {{/eq}}
+
+                {{#eq this "FAMILIEGJENFORENING"}}
+                    <li>Din første oppholdstillatelse som gav grunnlag for permanent oppholdstillatelse i Norge, ble
+                        gitt på grunn av familiegjenforening med barn, barnebarn, nevø eller niese. Det
+                        var krav om underhold, og du har derfor ikke rett til supplerende stønad.
+                    </li>
                 {{/eq}}
 
                 {{#eq this "FORMUE" }}
@@ -97,6 +131,24 @@
             Vedtaket er gjort etter lov om supplerende stønad for personer
             med kort botid i Norge {{> supdfgen/partials/visAvslagsparagrafer avslagsparagrafer}}.
         </span>
+
+        {{#each avslagsgrunner}}
+            {{#eq this "OPPHOLDSTILLATELSE"}}
+                {{#if erAldersbrev}}
+                    <p>Personer med registreringsbevis kan søke om varig oppholdsrett etter fem års botid i Norge.
+                        Retten til supplerende stønad kan tidligst oppnås når du har fått vedtak om varig oppholdsrett.
+                        Du kan søke om supplerende stønad på nytt når du er innvilget varig oppholdsrett i Norge.
+                    </p>
+                {{/if}}
+            {{/eq}}
+
+            {{#eq this "FAMILIEGJENFORENING"}}
+                <p>Selv om familiemedlemmet ditt ikke lenger sørger for ditt underhold, har du fremdeles ikke rett til
+                    supplerende stønad. Du kan ta kontakt med ditt lokale NAV-kontor for vurdering om du har rett til
+                    økonomisk sosialhjelp.
+                </p>
+            {{/eq}}
+        {{/each}}
 
         {{#if fritekst}}
             <p class="fritekst">{{fritekst}}</p>

--- a/templates/supdfgen/vedtakInnvilgelse.hbs
+++ b/templates/supdfgen/vedtakInnvilgelse.hbs
@@ -5,9 +5,14 @@
 
         <div class="info">
             <p>
-                Du får supplerende stønad fra {{fradato}} til og med {{tildato}} fordi du er ufør flyktning. Du kan søke på nytt i {{tildato}}.
+                Du får supplerende stønad fra {{fradato}} til og med {{tildato}} fordi du er
+                {{#if erAldersbrev}}
+                    over 67 år og har kort botid i Norge.
+                {{else}}
+                    ufør flyktning.
+                {{/if}}
+                Du kan søke på nytt i {{tildato}}.
             </p>
-
             <p>
                 Vedtaket er gjort etter lov om supplerende stønad til personer med kort botid i Norge, §§ 3, 5, 6 og 7.
             </p>


### PR DESCRIPTION
Trenger å få sendt med `erAldersbrev` fra bakover, se PR der for korresponderende endring. Tilleggene her er gjort med `if/else` på om det er aldersbrev, så det er bakoverkompatibelt i produksjon.